### PR TITLE
Migrate completed course relationship to single-pivot representation

### DIFF
--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -19,6 +20,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property int prereqCreditCount
  * @property int prereqCreditCountMajor
  * @property ?string prereqs
+ * @property Collection<int, Student> eligibleConcentrationStudents
+ * @property Collection<int, Student> completedStudents
  */
 class Course extends Model
 {
@@ -49,9 +52,18 @@ class Course extends Model
         return $this->belongsTo(User::class);
     }
 
+    /**
+     * TODO: remove once 'completed_courses_courses' table is gone
+     * @deprecated use `completedStudents()` instead
+     */
     public function completedCourses(): BelongsToMany
     {
         return $this->belongsToMany(CompletedCourses::class, 'completed_courses_courses');
+    }
+
+    public function completedStudents(): BelongsToMany
+    {
+        return $this->belongsToMany(Student::class, 'completed_courses_v2');
     }
 
     public function EligibleCoursesMajor(): BelongsToMany

--- a/database/migrations/2024_07_11_110024_create_completed_courses_courses_pivot_table.php
+++ b/database/migrations/2024_07_11_110024_create_completed_courses_courses_pivot_table.php
@@ -1,14 +1,11 @@
 <?php
 
-use App\Models\CompletedCourses;
 use App\Models\Course;
-use App\Models\Student;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */
@@ -17,7 +14,8 @@ return new class extends Migration
         Schema::create('completed_courses_courses', function (Blueprint $table) {
             $table->id();
             $table->foreignIdFor(Course::class);
-            $table->foreignIdFor(CompletedCourses::class);
+            $table->foreignId('completed_courses_id')
+                ->constrained('completed_courses');
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_07_30_013744_replace_completed_courses_table.php
+++ b/database/migrations/2024_07_30_013744_replace_completed_courses_table.php
@@ -12,14 +12,14 @@ return new class extends Migration {
      */
     public function up(): void
     {
-        Schema::create('new_completed_courses', function (Blueprint $table) {
+        Schema::create('completed_courses_v2', function (Blueprint $table) {
             $table->id();
             $table->foreignIdFor(Course::class);
             $table->foreignIdFor(Student::class);
             $table->timestamps();
         });
         DB::statement(<<<SQL
-            INSERT INTO new_completed_courses (id, course_id, student_id, created_at, updated_at)
+            INSERT INTO completed_courses_v2 (id, course_id, student_id, created_at, updated_at)
             SELECT ECCC.id, ECCC.course_id, ECC.student_id, ECCC.created_at, ECCC.updated_at
             FROM completed_courses_courses AS ECCC
             INNER JOIN completed_courses AS ECC
@@ -36,12 +36,12 @@ return new class extends Migration {
         DB::statement(<<<SQL
             INSERT INTO completed_courses_courses (id, course_id, completed_courses_id, created_at, updated_at)
                 SELECT E.id, E.course_id, ECC.id, E.created_at, E.updated_at
-                FROM new_completed_courses as E
+                FROM completed_courses_v2 as E
                 INNER JOIN completed_courses AS ECC
                     ON ECC.student_id = E.student_id
             ON CONFLICT(id) DO NOTHING
         SQL
         );
-        Schema::dropIfExists('new_completed_courses');
+        Schema::dropIfExists('completed_courses_v2');
     }
 };

--- a/database/migrations/2024_07_30_013744_replace_completed_courses_table.php
+++ b/database/migrations/2024_07_30_013744_replace_completed_courses_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Models\Course;
+use App\Models\Student;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('new_completed_courses', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(Course::class);
+            $table->foreignIdFor(Student::class);
+            $table->timestamps();
+        });
+        DB::statement(<<<SQL
+            INSERT INTO new_completed_courses (id, course_id, student_id, created_at, updated_at)
+            SELECT ECCC.id, ECCC.course_id, ECC.student_id, ECCC.created_at, ECCC.updated_at
+            FROM completed_courses_courses AS ECCC
+            INNER JOIN completed_courses AS ECC
+                ON ECC.id = ECCC.completed_courses_id
+        SQL
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement(<<<SQL
+            INSERT INTO completed_courses_courses (id, course_id, completed_courses_id, created_at, updated_at)
+                SELECT E.id, E.course_id, ECC.id, E.created_at, E.updated_at
+                FROM new_completed_courses as E
+                INNER JOIN completed_courses AS ECC
+                    ON ECC.student_id = E.student_id
+            ON CONFLICT(id) DO NOTHING
+        SQL
+        );
+        Schema::dropIfExists('new_completed_courses');
+    }
+};

--- a/resources/views/students/edit.blade.php
+++ b/resources/views/students/edit.blade.php
@@ -92,7 +92,7 @@
                 id="taArray"
                 name="coursesCompleted"
                 class="mt-1 block w-full border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 rounded-md shadow-sm"
-            >{{ old('coursesCompleted') }}@if(!old('coursesCompleted') && !is_null($student->completedCourses))@foreach($student->completedCourses->course as $cc){{$cc->code}}@if ($loop->remaining > 0){{ "," }}@endif @endforeach @endif</textarea>
+            >{{ old('coursesCompleted') }}@if(!old('coursesCompleted') && !is_null($student->completedCoursesV2))@foreach($student->completedCoursesV2 as $cc){{$cc->code}}@if ($loop->remaining > 0){{ "," }}@endif @endforeach @endif</textarea>
             <div class="mt-4 space-x-2">
                 <x-primary-button class="mt-4">{{ __('Update') }}</x-primary-button>
                     <a href="{{ route('students.index') }}">{{ __('Cancel') }}</a>

--- a/resources/views/students/show.blade.php
+++ b/resources/views/students/show.blade.php
@@ -74,7 +74,7 @@
         <div class = "mt-4">
             <p class="font-bold">Completed Courses</p>
             <div class="p-2 h-40 overflow-y-auto bg-white border border-gray-300 block w-full focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 rounded-md shadow-sm">
-                @foreach($student->completedCourses->course as $courseCompleted)
+                @foreach($student->completedCoursesV2 as $courseCompleted)
                     <div class="tooltip-container">
                         {{ $courseCompleted->code }}: {{$courseCompleted->name}}
                         <div class = "tooltip w-auto bg-gray-200 p-1 rounded-md ml-2">


### PR DESCRIPTION
Continuing off https://github.com/DoktorNik/course-companion/pull/23, this PR identical changes for the completed course double-pivot relationship: from`completed_courses` + `completed_courses_courses` double-pivot table into a single `completed_courses_v2` single-pivot table.

See https://github.com/DoktorNik/course-companion/pull/23 and https://github.com/DoktorNik/course-companion/issues/24 for more details.

> [!NOTE]
> The `completed_courses_v2` table should be renamed to `completed_courses` after the current `completed_courses` + `completed_courses_courses` double-pivot relationship is removed.

---

|![Course Companion WIP](https://github.com/user-attachments/assets/9573171e-9376-475e-b6af-33af549603fe)|
|:--:|
|Current schema once this PR is merged|
