### PR TITLE
Migrate eligible elective major course relationship to single-pivot representation 

### DIFF
--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -278,7 +278,7 @@ class StudentController extends Controller
                     $student->markAsEligibleForConcentrationCourse($course);
                 } else {
                     if (substr($course->code, 0, 4) == $student->major) {
-                        $this->createRelatedCourseRecord($student, "ElectiveMajor", $course->code);
+                        $student->markAsEligibleForElectiveMajorCourse($course);
                     } else {
                         $this->createRelatedCourseRecord($student, "Elective", $course->code);
                     }
@@ -321,9 +321,7 @@ class StudentController extends Controller
             // remove from prereqs
             $student->markAsNoLongerEligibleForMajorCourse($course);
             $student->markAsNoLongerEligibleForConcentrationCourse($course);
-            if (isset($student->eligibleCoursesElectiveMajor)) {
-                $course->eligibleCoursesElectiveMajor()->detach($student->eligibleCoursesElectiveMajor);
-            }
+            $student->markAsNoLongerEligibleForElectiveMajorCourse($course);
             // not implemented
             /*
             if(isset($student->eligibleCoursesContext)) {
@@ -373,7 +371,8 @@ class StudentController extends Controller
             /* DEPRECATED: use Student::markAsEligibleForConcentrationCourse instead */
             return;
         } elseif ($type == "ElectiveMajor") {
-            $sc = $student->eligibleCoursesElectiveMajor;
+            /* DEPRECATED: use Student::markAsEligibleForElectiveMajorCourse instead */
+            return;
         } elseif ($type == "Context") {
             $sc = $student->eligibleCoursesContext;
         } elseif ($type == "Elective") {
@@ -382,9 +381,7 @@ class StudentController extends Controller
 
         // add the course if it hasn't been added already
         if (!$this->relatedCourseRecordExists($sc, $course)) {
-            if ($type == "ElectiveMajor") {
-                $course->EligibleCoursesElectiveMajor()->attach($sc);
-            } elseif ($type == "Context") {
+            if ($type == "Context") {
                 $course->EligibleCoursesContext()->attach($sc);
             } elseif ($type == "Elective") {
                 $course->EligibleCoursesElective()->attach($sc);

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -55,7 +55,7 @@ class Course extends Model
 
     /**
      * TODO: remove once 'completed_courses_courses' table is gone
-     * @deprecated use `completedStudents()` instead
+     * @deprecated use {@link self::completedStudents()} instead
      */
     public function completedCourses(): BelongsToMany
     {
@@ -69,7 +69,7 @@ class Course extends Model
 
     /**
      * TODO: remove once 'eligible_courses_major_courses' table is gone
-     * @deprecated use `eligibleMajorStudents()` instead
+     * @deprecated use {@link self::eligibleMajorStudents()} instead
      */
     public function EligibleCoursesMajor(): BelongsToMany
     {
@@ -83,7 +83,7 @@ class Course extends Model
 
     /**
      * TODO: remove once 'eligible_courses_concentration_courses' table is gone
-     * @deprecated use `eligibleConcentrationStudents()` instead
+     * @deprecated use {@link self::eligibleConcentrationStudents()} instead
      */
     public function EligibleCoursesConcentration(): BelongsToMany
     {
@@ -95,9 +95,18 @@ class Course extends Model
         return $this->belongsToMany(Student::class, 'eligible_concentration_courses');
     }
 
+    /**
+     * TODO: remove once 'eligible_courses_elective_major_courses' table is gone
+     * @deprecated use {@link self::eligibleElectiveMajorStudents()}
+     */
     public function EligibleCoursesElectiveMajor(): BelongsToMany
     {
         return $this->BelongsToMany(EligibleCoursesElectiveMajor::class, 'eligible_courses_elective_major_courses');
+    }
+
+    public function eligibleElectiveMajorStudents(): BelongsToMany
+    {
+        return $this->belongsToMany(Student::class, 'eligible_elective_major_courses');
     }
 
     public function EligibleCoursesElective(): BelongsToMany

--- a/app/Models/EligibleCoursesElectiveMajor.php
+++ b/app/Models/EligibleCoursesElectiveMajor.php
@@ -6,6 +6,9 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
+/**
+ * @deprecated
+ */
 class EligibleCoursesElectiveMajor extends Model
 {
     use HasFactory;

--- a/database/migrations/2024_07_11_173445_eligible_courses_elective_majors_courses_pivot_table.php
+++ b/database/migrations/2024_07_11_173445_eligible_courses_elective_majors_courses_pivot_table.php
@@ -1,16 +1,11 @@
 <?php
 
-use App\Models\CompletedCourses;
 use App\Models\Course;
-use App\Models\EligibleCoursesElectiveMajor;
-use App\Models\EligibleCoursesMajor;
-use App\Models\Student;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */
@@ -19,7 +14,8 @@ return new class extends Migration
         Schema::create('eligible_courses_elective_major_courses', function (Blueprint $table) {
             $table->id();
             $table->foreignIdFor(Course::class);
-            $table->foreignIdFor(EligibleCoursesElectiveMajor::class);
+            $table->foreignId('eligible_courses_elective_major_id')
+                ->constrained('eligible_courses_elective_majors');
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_08_07_021256_replace_eligible_courses_elective_majors_table.php
+++ b/database/migrations/2024_08_07_021256_replace_eligible_courses_elective_majors_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Models\Course;
+use App\Models\Student;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('eligible_elective_major_courses', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(Course::class);
+            $table->foreignIdFor(Student::class);
+            $table->timestamps();
+        });
+        DB::statement(<<<SQL
+            INSERT INTO eligible_elective_major_courses (id, course_id, student_id, created_at, updated_at)
+            SELECT ECCC.id, ECCC.course_id, ECC.student_id, ECCC.created_at, ECCC.updated_at
+            FROM eligible_courses_elective_major_courses AS ECCC
+            INNER JOIN eligible_courses_elective_majors AS ECC
+                ON ECC.id = ECCC.eligible_courses_elective_major_id
+        SQL
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement(<<<SQL
+            INSERT INTO eligible_courses_elective_major_courses (id, course_id, eligible_courses_elective_major_id, created_at, updated_at)
+                SELECT E.id, E.course_id, ECC.id, E.created_at, E.updated_at
+                FROM eligible_elective_major_courses as E
+                INNER JOIN eligible_courses_elective_majors AS ECC
+                    ON ECC.student_id = E.student_id
+            ON CONFLICT(id) DO NOTHING
+        SQL
+        );
+        Schema::dropIfExists('eligible_elective_major_courses');
+    }
+};

--- a/resources/views/students/show.blade.php
+++ b/resources/views/students/show.blade.php
@@ -123,7 +123,7 @@
         <div class = "mt-4">
             <p class="font-bold">Eligible Major Elective Courses</p>
             <div class="p-2 h-40 overflow-y-auto bg-white border border-gray-300 block w-full focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 rounded-md shadow-sm">
-                @foreach($student->eligibleCoursesElectiveMajor->course as $courseCompleted)
+                @foreach($student->eligibleElectiveMajorCourses as $courseCompleted)
                     <div class="tooltip-container">
                         {{ $courseCompleted->code }}: {{$courseCompleted->name}}
                         @if($courseCompleted->minimumGrade)


### PR DESCRIPTION
This PR implements a single-pivot many-to-many relationship for eligible elective major courses alongside the current double-pivot implementation.

See https://github.com/DoktorNik/course-companion/pull/23 and https://github.com/DoktorNik/course-companion/issues/24 for more details on why this is necessary.