### PR TITLE
Migrate eligible elective course relationship to single-pivot representation

### DIFF
--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -280,7 +280,7 @@ class StudentController extends Controller
                     if (substr($course->code, 0, 4) == $student->major) {
                         $student->markAsEligibleForElectiveMajorCourse($course);
                     } else {
-                        $this->createRelatedCourseRecord($student, "Elective", $course->code);
+                        $student->markAsEligibleForElectiveCourse($course);
                     }
                 }
             }
@@ -328,9 +328,7 @@ class StudentController extends Controller
                 $course->eligibleCoursesContext()->detach($student->eligibleCoursesContext);
             }
             */
-            if (isset($student->eligibleCoursesElective)) {
-                $course->eligibleCoursesElective()->detach($student->eligibleCoursesElective);
-            }
+            $student->markAsNoLongerEligibleForElectiveCourse($course);
         }
     }
 
@@ -376,15 +374,14 @@ class StudentController extends Controller
         } elseif ($type == "Context") {
             $sc = $student->eligibleCoursesContext;
         } elseif ($type == "Elective") {
-            $sc = $student->eligibleCoursesElective;
+            /* DEPRECATED: use Student::markAsEligibleForElectiveCourse instead */
+            return;
         }
 
         // add the course if it hasn't been added already
         if (!$this->relatedCourseRecordExists($sc, $course)) {
             if ($type == "Context") {
                 $course->EligibleCoursesContext()->attach($sc);
-            } elseif ($type == "Elective") {
-                $course->EligibleCoursesElective()->attach($sc);
             }
         }
     }

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -22,6 +22,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property ?string prereqs
  * @property Collection<int, Student> eligibleConcentrationStudents
  * @property Collection<int, Student> eligibleMajorStudents
+ * @property Collection<int, Student> eligibleElectiveStudents
  * @property Collection<int, Student> completedStudents
  */
 class Course extends Model
@@ -109,9 +110,18 @@ class Course extends Model
         return $this->belongsToMany(Student::class, 'eligible_elective_major_courses');
     }
 
+    /**
+     * TODO: remove once 'eligible_courses_elective_major_courses' table is gone
+     * @deprecated use {@link self::eligibleElectiveStudents()}
+     */
     public function EligibleCoursesElective(): BelongsToMany
     {
         return $this->BelongsToMany(EligibleCoursesElective::class, 'eligible_courses_elective_courses');
+    }
+
+    public function eligibleElectiveStudents(): BelongsToMany
+    {
+        return $this->belongsToMany(Student::class, 'eligible_elective_courses');
     }
 
     public function CourseFeedback(): HasMany

--- a/app/Models/EligibleCoursesElective.php
+++ b/app/Models/EligibleCoursesElective.php
@@ -6,6 +6,9 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
+/**
+ * @deprecated
+ */
 class EligibleCoursesElective extends Model
 {
     use HasFactory;

--- a/database/migrations/2024_07_11_173657_eligible_courses_elective_courses_pivot_table.php
+++ b/database/migrations/2024_07_11_173657_eligible_courses_elective_courses_pivot_table.php
@@ -1,16 +1,11 @@
 <?php
 
-use App\Models\CompletedCourses;
 use App\Models\Course;
-use App\Models\EligibleCoursesElective;
-use App\Models\EligibleCoursesMajor;
-use App\Models\Student;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */
@@ -19,7 +14,8 @@ return new class extends Migration
         Schema::create('eligible_courses_elective_courses', function (Blueprint $table) {
             $table->id();
             $table->foreignIdFor(Course::class);
-            $table->foreignIdFor(EligibleCoursesElective::class);
+            $table->foreignId('eligible_courses_elective_id')
+                ->constrained('eligible_courses_electives');
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_08_07_215813_replace_eligible_courses_electives_table.php
+++ b/database/migrations/2024_08_07_215813_replace_eligible_courses_electives_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Models\Course;
+use App\Models\Student;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('eligible_elective_courses', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(Course::class);
+            $table->foreignIdFor(Student::class);
+            $table->timestamps();
+        });
+        DB::statement(<<<SQL
+            INSERT INTO eligible_elective_courses (id, course_id, student_id, created_at, updated_at)
+            SELECT ECCC.id, ECCC.course_id, ECC.student_id, ECCC.created_at, ECCC.updated_at
+            FROM eligible_courses_elective_courses AS ECCC
+            INNER JOIN eligible_courses_electives AS ECC
+                ON ECC.id = ECCC.eligible_courses_elective_id
+        SQL
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement(<<<SQL
+            INSERT INTO eligible_courses_elective_courses (id, course_id, eligible_courses_elective_id, created_at, updated_at)
+                SELECT E.id, E.course_id, ECC.id, E.created_at, E.updated_at
+                FROM eligible_elective_courses as E
+                INNER JOIN eligible_courses_electives AS ECC
+                    ON ECC.student_id = E.student_id
+            ON CONFLICT(id) DO NOTHING
+        SQL
+        );
+        Schema::dropIfExists('eligible_elective_courses');
+    }
+};

--- a/resources/views/students/show.blade.php
+++ b/resources/views/students/show.blade.php
@@ -139,7 +139,7 @@
         <div class = "mt-4">
             <p class="font-bold">Eligible Non-Major Elective Courses</p>
         <div class="p-2 h-40 overflow-y-auto bg-white border border-gray-300 block w-full focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 rounded-md shadow-sm">
-            @foreach($student->eligibleCoursesElective->course as $courseCompleted)
+            @foreach($student->eligibleElectiveCourses as $courseCompleted)
                 <div class="tooltip-container">
                     {{ $courseCompleted->code }}: {{$courseCompleted->name}}
                     @if($courseCompleted->minimumGrade)


### PR DESCRIPTION
This PR implements a single-pivot many-to-many relationship for eligible elective courses alongside the current double-pivot implementation.

See https://github.com/DoktorNik/course-companion/pull/23 and https://github.com/DoktorNik/course-companion/issues/24 for more details on why this is necessary.