### PR TITLE
Migrate eligible context course relationship to single-pivot representation

### DIFF
--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -322,12 +322,6 @@ class StudentController extends Controller
             $student->markAsNoLongerEligibleForMajorCourse($course);
             $student->markAsNoLongerEligibleForConcentrationCourse($course);
             $student->markAsNoLongerEligibleForElectiveMajorCourse($course);
-            // not implemented
-            /*
-            if(isset($student->eligibleCoursesContext)) {
-                $course->eligibleCoursesContext()->detach($student->eligibleCoursesContext);
-            }
-            */
             $student->markAsNoLongerEligibleForElectiveCourse($course);
         }
     }
@@ -372,7 +366,8 @@ class StudentController extends Controller
             /* DEPRECATED: use Student::markAsEligibleForElectiveMajorCourse instead */
             return;
         } elseif ($type == "Context") {
-            $sc = $student->eligibleCoursesContext;
+            /* DEPRECATED: use Student::markAsEligibleForElectiveCourse instead */
+            return;
         } elseif ($type == "Elective") {
             /* DEPRECATED: use Student::markAsEligibleForElectiveCourse instead */
             return;
@@ -380,9 +375,7 @@ class StudentController extends Controller
 
         // add the course if it hasn't been added already
         if (!$this->relatedCourseRecordExists($sc, $course)) {
-            if ($type == "Context") {
-                $course->EligibleCoursesContext()->attach($sc);
-            }
+
         }
     }
 }

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -23,6 +23,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property Collection<int, Student> eligibleConcentrationStudents
  * @property Collection<int, Student> eligibleMajorStudents
  * @property Collection<int, Student> eligibleElectiveStudents
+ * @property Collection<int, Student> eligibleElectiveMajorStudents
  * @property Collection<int, Student> completedStudents
  */
 class Course extends Model

--- a/app/Models/EligibleCoursesContext.php
+++ b/app/Models/EligibleCoursesContext.php
@@ -6,6 +6,9 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
+/**
+ * @deprecated
+ */
 class EligibleCoursesContext extends Model
 {
     use HasFactory;

--- a/app/Models/Student.php
+++ b/app/Models/Student.php
@@ -22,6 +22,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property Collection<int, Course> completedCoursesV2
  * @property Collection<int, Course> eligibleElectiveMajorCourses
  * @property Collection<int, Course> eligibleElectiveCourses
+ * @property Collection<int, Course> eligibleContextCourses
  */
 class Student extends Model
 {
@@ -208,9 +209,18 @@ class Student extends Model
         return $this->belongsToMany(Course::class, 'eligible_elective_major_courses');
     }
 
+    /**
+     * TODO: remove once 'eligible_courses_context_courses' table is gone
+     * @deprecated use {@link self::eligibleContextCourses()} instead
+     */
     public function EligibleCoursesContext(): hasOne
     {
         return $this->hasOne(EligibleCoursesContext::class);
+    }
+
+    public function eligibleContextCourses(): BelongsToMany
+    {
+        return $this->belongsToMany(Course::class, 'eligible_context_courses');
     }
 
     /**

--- a/database/migrations/2024_07_11_173054_eligible_courses_context_pivot_table.php
+++ b/database/migrations/2024_07_11_173054_eligible_courses_context_pivot_table.php
@@ -1,15 +1,11 @@
 <?php
 
-use App\Models\CompletedCourses;
 use App\Models\Course;
-use App\Models\EligibleCoursesMajor;
-use App\Models\Student;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */
@@ -18,7 +14,8 @@ return new class extends Migration
         Schema::create('eligible_courses_context_courses', function (Blueprint $table) {
             $table->id();
             $table->foreignIdFor(Course::class);
-            $table->foreignIdFor(EligibleCoursesMajor::class);
+            $table->foreignId('eligible_courses_major_id')
+                ->constrained('eligible_courses_contexts');
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_07_30_013744_replace_completed_courses_table.php
+++ b/database/migrations/2024_07_30_013744_replace_completed_courses_table.php
@@ -4,6 +4,7 @@ use App\Models\Course;
 use App\Models\Student;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration {

--- a/database/migrations/2024_08_01_180832_replace_eligible_courses_majors_table.php
+++ b/database/migrations/2024_08_01_180832_replace_eligible_courses_majors_table.php
@@ -4,6 +4,7 @@ use App\Models\Course;
 use App\Models\Student;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration {

--- a/database/migrations/2024_08_07_021256_replace_eligible_courses_elective_majors_table.php
+++ b/database/migrations/2024_08_07_021256_replace_eligible_courses_elective_majors_table.php
@@ -4,6 +4,7 @@ use App\Models\Course;
 use App\Models\Student;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration {

--- a/database/migrations/2024_08_07_234931_replace_eligible_courses_contexts_table.php
+++ b/database/migrations/2024_08_07_234931_replace_eligible_courses_contexts_table.php
@@ -13,18 +13,18 @@ return new class extends Migration {
      */
     public function up(): void
     {
-        Schema::create('eligible_elective_courses', function (Blueprint $table) {
+        Schema::create('eligible_context_courses', function (Blueprint $table) {
             $table->id();
             $table->foreignIdFor(Course::class);
             $table->foreignIdFor(Student::class);
             $table->timestamps();
         });
         DB::statement(<<<SQL
-            INSERT INTO eligible_elective_courses (id, course_id, student_id, created_at, updated_at)
+            INSERT INTO eligible_context_courses (id, course_id, student_id, created_at, updated_at)
             SELECT ECCC.id, ECCC.course_id, ECC.student_id, ECCC.created_at, ECCC.updated_at
-            FROM eligible_courses_elective_courses AS ECCC
-            INNER JOIN eligible_courses_electives AS ECC
-                ON ECC.id = ECCC.eligible_courses_elective_id
+            FROM eligible_courses_context_courses AS ECCC
+            INNER JOIN eligible_courses_contexts AS ECC
+                ON ECC.id = ECCC.eligible_courses_major_id
         SQL
         );
     }
@@ -35,14 +35,14 @@ return new class extends Migration {
     public function down(): void
     {
         DB::statement(<<<SQL
-            INSERT INTO eligible_courses_elective_courses (id, course_id, eligible_courses_elective_id, created_at, updated_at)
+            INSERT INTO eligible_courses_context_courses (id, course_id, eligible_courses_major_id, created_at, updated_at)
                 SELECT E.id, E.course_id, ECC.id, E.created_at, E.updated_at
-                FROM eligible_elective_courses as E
-                INNER JOIN eligible_courses_electives AS ECC
+                FROM eligible_context_courses as E
+                INNER JOIN eligible_courses_contexts AS ECC
                     ON ECC.student_id = E.student_id
             ON CONFLICT(id) DO NOTHING
         SQL
         );
-        Schema::dropIfExists('eligible_elective_courses');
+        Schema::dropIfExists('eligible_context_courses');
     }
 };


### PR DESCRIPTION
This PR implements a single-pivot many-to-many relationship for eligible context courses alongside the current double-pivot implementation.

See https://github.com/DoktorNik/course-companion/pull/23 and https://github.com/DoktorNik/course-companion/issues/24 for more details on why this is necessary.